### PR TITLE
Add Play History feature with backend API and frontend table

### DIFF
--- a/backend/src/library/dto/play-history.dto.ts
+++ b/backend/src/library/dto/play-history.dto.ts
@@ -1,0 +1,108 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class GetPlayHistoryQueryDto {
+  @ApiPropertyOptional({ default: 1, description: 'Page number', minimum: 1 })
+  @IsInt()
+  @IsOptional()
+  @Min(1)
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    default: 50,
+    description: 'Page size',
+    maximum: 1000,
+    minimum: 1,
+  })
+  @IsInt()
+  @IsOptional()
+  @Max(1000)
+  @Min(1)
+  @Type(() => Number)
+  pageSize?: number = 50;
+
+  @ApiPropertyOptional({
+    description: 'Search query for title, artist or album',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by track ID',
+  })
+  @IsOptional()
+  @IsString()
+  trackId?: string;
+}
+
+export class PaginatedPlayHistoryDto {
+  @ApiProperty({ type: () => [PlayHistoryItemDto] })
+  @Expose()
+  @Type(() => PlayHistoryItemDto)
+  items: PlayHistoryItemDto[];
+
+  @ApiProperty()
+  @Expose()
+  page: number;
+
+  @ApiProperty()
+  @Expose()
+  pageSize: number;
+
+  @ApiProperty()
+  @Expose()
+  total: number;
+
+  @ApiProperty()
+  @Expose()
+  totalPages: number;
+}
+
+export class PlayHistoryItemDto {
+  @ApiPropertyOptional({
+    description: 'Duration listened in milliseconds',
+    nullable: true,
+  })
+  @Expose()
+  duration?: number;
+
+  @ApiProperty()
+  @Expose()
+  id: string;
+
+  @ApiProperty()
+  @Expose()
+  playedAt: Date;
+
+  @ApiPropertyOptional()
+  @Expose()
+  trackAlbum?: string;
+
+  @ApiPropertyOptional()
+  @Expose()
+  trackAlbumArt?: string;
+
+  @ApiProperty()
+  @Expose()
+  trackArtist: string;
+
+  @ApiProperty({ description: 'Track duration in milliseconds' })
+  @Expose()
+  trackDuration: number;
+
+  // Track information
+  @ApiProperty()
+  @Expose()
+  trackId: string;
+
+  @ApiProperty()
+  @Expose()
+  trackSpotifyId: string;
+
+  @ApiProperty()
+  @Expose()
+  trackTitle: string;
+}

--- a/backend/src/library/dto/sync-progress-base.dto.ts
+++ b/backend/src/library/dto/sync-progress-base.dto.ts
@@ -78,7 +78,8 @@ export class SyncProgressDto {
   errorCount: number;
 
   @ApiProperty({
-    description: 'List of non-fatal errors encountered (deprecated, use errorCount for progress updates)',
+    description:
+      'List of non-fatal errors encountered (deprecated, use errorCount for progress updates)',
     required: false,
   })
   errors?: string[];

--- a/backend/src/library/library-sync.service.ts
+++ b/backend/src/library/library-sync.service.ts
@@ -215,8 +215,15 @@ export class LibrarySyncService {
           // Calculate percentage, ensuring it's finite and clamped 66-100
           let percentage = 66;
           if (playlists.length > 0) {
-            const rawPercentage = 66 + (processedPlaylists / playlists.length) * 34;
-            percentage = Math.min(100, Math.max(66, Number.isFinite(rawPercentage) ? Math.round(rawPercentage) : 66));
+            const rawPercentage =
+              66 + (processedPlaylists / playlists.length) * 34;
+            percentage = Math.min(
+              100,
+              Math.max(
+                66,
+                Number.isFinite(rawPercentage) ? Math.round(rawPercentage) : 66,
+              ),
+            );
           }
 
           await onProgress({
@@ -1498,7 +1505,8 @@ export class LibrarySyncService {
       if (!forceEmit && estimatedTotal === 0) return;
 
       const elapsed = Date.now() - startTime;
-      const rawItemsPerSecond = totalProcessed / Math.max(elapsed / 1000, 0.001);
+      const rawItemsPerSecond =
+        totalProcessed / Math.max(elapsed / 1000, 0.001);
       const itemsPerSecond = Math.max(0, rawItemsPerSecond);
       const remaining = Math.max(0, estimatedTotal - totalProcessed);
 
@@ -1506,21 +1514,31 @@ export class LibrarySyncService {
       let estimatedTimeRemaining: number | undefined;
       if (itemsPerSecond > 0 && remaining > 0) {
         const rawEtr = remaining / itemsPerSecond;
-        estimatedTimeRemaining = Number.isFinite(rawEtr) ? Math.round(Math.max(0, rawEtr)) : undefined;
+        estimatedTimeRemaining = Number.isFinite(rawEtr)
+          ? Math.round(Math.max(0, rawEtr))
+          : undefined;
       }
 
       // Calculate percentage, ensuring it's finite and clamped 0-100
       let percentage = 33;
       if (estimatedTotal > 0) {
         const rawPercentage = 33 + (totalProcessed / estimatedTotal) * 33;
-        percentage = Math.min(66, Math.max(33, Number.isFinite(rawPercentage) ? Math.round(rawPercentage) : 33));
+        percentage = Math.min(
+          66,
+          Math.max(
+            33,
+            Number.isFinite(rawPercentage) ? Math.round(rawPercentage) : 33,
+          ),
+        );
       }
 
       await onProgress({
         current: totalProcessed,
         errorCount: result.errors.length,
         estimatedTimeRemaining,
-        itemsPerSecond: Number.isFinite(itemsPerSecond) ? Math.round(itemsPerSecond) : 0,
+        itemsPerSecond: Number.isFinite(itemsPerSecond)
+          ? Math.round(itemsPerSecond)
+          : 0,
         message: `Processing albums: ${totalProcessed}/${estimatedTotal}`,
         percentage,
         phase: 'albums',
@@ -1608,7 +1626,8 @@ export class LibrarySyncService {
       if (!forceEmit && estimatedTotal === 0) return;
 
       const elapsed = Date.now() - startTime;
-      const rawItemsPerSecond = totalProcessed / Math.max(elapsed / 1000, 0.001);
+      const rawItemsPerSecond =
+        totalProcessed / Math.max(elapsed / 1000, 0.001);
       const itemsPerSecond = Math.max(0, rawItemsPerSecond);
       const remaining = Math.max(0, estimatedTotal - totalProcessed);
 
@@ -1616,21 +1635,31 @@ export class LibrarySyncService {
       let estimatedTimeRemaining: number | undefined;
       if (itemsPerSecond > 0 && remaining > 0) {
         const rawEtr = remaining / itemsPerSecond;
-        estimatedTimeRemaining = Number.isFinite(rawEtr) ? Math.round(Math.max(0, rawEtr)) : undefined;
+        estimatedTimeRemaining = Number.isFinite(rawEtr)
+          ? Math.round(Math.max(0, rawEtr))
+          : undefined;
       }
 
       // Calculate percentage, ensuring it's finite and clamped 0-100
       let percentage = 0;
       if (estimatedTotal > 0) {
         const rawPercentage = (totalProcessed / estimatedTotal) * 33;
-        percentage = Math.min(33, Math.max(0, Number.isFinite(rawPercentage) ? Math.round(rawPercentage) : 0));
+        percentage = Math.min(
+          33,
+          Math.max(
+            0,
+            Number.isFinite(rawPercentage) ? Math.round(rawPercentage) : 0,
+          ),
+        );
       }
 
       await onProgress({
         current: totalProcessed,
         errorCount: result.errors.length,
         estimatedTimeRemaining,
-        itemsPerSecond: Number.isFinite(itemsPerSecond) ? Math.round(itemsPerSecond) : 0,
+        itemsPerSecond: Number.isFinite(itemsPerSecond)
+          ? Math.round(itemsPerSecond)
+          : 0,
         message: `Processing tracks: ${totalProcessed}/${estimatedTotal}`,
         percentage,
         phase: 'tracks',

--- a/backend/src/library/library.controller.ts
+++ b/backend/src/library/library.controller.ts
@@ -33,6 +33,10 @@ import { ArtistTracksResponseDto } from './dto/artist-tracks.dto';
 import { PaginatedArtistsDto } from './dto/artist.dto';
 import { GetAlbumsQueryDto } from './dto/get-albums-query.dto';
 import { GetArtistsQueryDto } from './dto/get-artists-query.dto';
+import {
+  GetPlayHistoryQueryDto,
+  PaginatedPlayHistoryDto,
+} from './dto/play-history.dto';
 import { UpdateRatingDto } from './dto/rating.dto';
 import {
   SyncItemCountsDto,
@@ -229,6 +233,20 @@ export class LibraryController {
   @Get('genres')
   async getGenres(@Req() req: AuthenticatedRequest): Promise<string[]> {
     return this.trackService.getUserGenres(req.user.id);
+  }
+
+  @ApiOperation({ summary: 'Get user play history' })
+  @ApiResponse({
+    description: 'Paginated list of play history',
+    status: 200,
+    type: PaginatedPlayHistoryDto,
+  })
+  @Get('play-history')
+  async getPlayHistory(
+    @Req() req: AuthenticatedRequest,
+    @Query() query: GetPlayHistoryQueryDto,
+  ): Promise<PaginatedPlayHistoryDto> {
+    return this.trackService.getPlayHistory(req.user.id, query);
   }
 
   // Tag management endpoints

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -684,6 +684,75 @@
         ]
       }
     },
+    "/library/play-history": {
+      "get": {
+        "operationId": "LibraryController_getPlayHistory",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number",
+            "schema": {
+              "minimum": 1,
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "pageSize",
+            "required": false,
+            "in": "query",
+            "description": "Page size",
+            "schema": {
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 50,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "Search query for title, artist or album",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "trackId",
+            "required": false,
+            "in": "query",
+            "description": "Filter by track ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of play history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedPlayHistoryDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get user play history",
+        "tags": [
+          "library"
+        ]
+      }
+    },
     "/library/sync/count": {
       "get": {
         "operationId": "LibraryController_getSyncItemCounts",
@@ -1883,6 +1952,84 @@
         },
         "required": [
           "tracks"
+        ]
+      },
+      "PlayHistoryItemDto": {
+        "type": "object",
+        "properties": {
+          "duration": {
+            "type": "number",
+            "description": "Duration listened in milliseconds",
+            "nullable": true
+          },
+          "id": {
+            "type": "string"
+          },
+          "playedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "trackAlbum": {
+            "type": "string"
+          },
+          "trackAlbumArt": {
+            "type": "string"
+          },
+          "trackArtist": {
+            "type": "string"
+          },
+          "trackDuration": {
+            "type": "number",
+            "description": "Track duration in milliseconds"
+          },
+          "trackId": {
+            "type": "string"
+          },
+          "trackSpotifyId": {
+            "type": "string"
+          },
+          "trackTitle": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "playedAt",
+          "trackArtist",
+          "trackDuration",
+          "trackId",
+          "trackSpotifyId",
+          "trackTitle"
+        ]
+      },
+      "PaginatedPlayHistoryDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlayHistoryItemDto"
+            }
+          },
+          "page": {
+            "type": "number"
+          },
+          "pageSize": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          },
+          "totalPages": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "items",
+          "page",
+          "pageSize",
+          "total",
+          "totalPages"
         ]
       },
       "SyncItemCountsDto": {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import { AppShell, Burger, Group, NavLink, Text } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { Link, useLocation } from "@tanstack/react-router";
-import { Disc, Home, Library, ListMusic, User } from "lucide-react";
+import { Disc, History, Home, Library, ListMusic, User } from "lucide-react";
 import { ReactNode } from "react";
 
 interface AppShellLayoutProps {
@@ -18,6 +18,7 @@ export function AppShellLayout({ children }: AppShellLayoutProps) {
     { icon: Disc, label: "Albums", to: "/albums" },
     { icon: User, label: "Artists", to: "/artists" },
     { icon: ListMusic, label: "Smart Playlists", to: "/playlists" },
+    { icon: History, label: "Play History", to: "/play-history" },
   ];
 
   return (

--- a/frontend/src/components/PlayHistoryTable.tsx
+++ b/frontend/src/components/PlayHistoryTable.tsx
@@ -1,0 +1,229 @@
+import {
+  Avatar,
+  Badge,
+  Center,
+  Group,
+  Loader,
+  Pagination,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { useDebouncedValue } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
+import { useNavigate } from "@tanstack/react-router";
+import { Music, Search } from "lucide-react";
+import { useState } from "react";
+
+import { useSpotifyPlayer } from "../contexts/SpotifyPlayerContext";
+import {
+  PlayHistoryItemDto,
+  useLibraryControllerGetPlayHistory,
+} from "../data/api";
+
+export function PlayHistoryTable() {
+  const navigate = useNavigate();
+  const [search, setSearch] = useState("");
+  const [debouncedSearch] = useDebouncedValue(search, 300);
+  const [page, setPage] = useState(1);
+  const pageSize = 50;
+
+  const { playTrackList } = useSpotifyPlayer();
+
+  const { data, isLoading } = useLibraryControllerGetPlayHistory({
+    page,
+    pageSize,
+    search: debouncedSearch || undefined,
+  });
+
+  const handlePlayTrack = async (
+    trackTitle: string,
+    spotifyId: string,
+    trackId: string,
+  ) => {
+    try {
+      await playTrackList(
+        [{ spotifyUri: `spotify:track:${spotifyId}`, trackId }],
+        0,
+      );
+
+      notifications.show({
+        color: "green",
+        message: trackTitle,
+        title: "Now playing",
+      });
+    } catch (error) {
+      notifications.show({
+        color: "red",
+        message:
+          (error as Error & { response?: { data?: { message?: string } } })
+            .response?.data?.message ||
+          "Please make sure Spotify is open on one of your devices",
+        title: "Failed to play track",
+      });
+    }
+  };
+
+  const formatDuration = (ms: number) => {
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.floor((ms % 60000) / 1000);
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  };
+
+  const formatDate = (date: string) => {
+    return new Date(date).toLocaleString("en-US", {
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <Center className="h-[400px]">
+        <Loader size="lg" />
+      </Center>
+    );
+  }
+
+  const totalPages = data?.totalPages || 1;
+  const items: PlayHistoryItemDto[] = data?.items || [];
+
+  return (
+    <Stack gap="md">
+      <TextInput
+        leftSection={<Search size={16} />}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        placeholder="Search tracks, artists, or albums..."
+        value={search}
+      />
+
+      <div className="overflow-x-auto">
+        <Table
+          highlightOnHover
+          horizontalSpacing="md"
+          striped
+          verticalSpacing="sm"
+          withTableBorder
+        >
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Track</Table.Th>
+              <Table.Th>Artist</Table.Th>
+              <Table.Th>Album</Table.Th>
+              <Table.Th>Played At</Table.Th>
+              <Table.Th>Duration</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {items.length === 0 ? (
+              <Table.Tr>
+                <Table.Td className="text-center text-gray-500" colSpan={5}>
+                  No play history found
+                </Table.Td>
+              </Table.Tr>
+            ) : (
+              items.map((item) => (
+                <Table.Tr
+                  className="cursor-pointer hover:bg-gray-50"
+                  key={item.id}
+                  onClick={() =>
+                    handlePlayTrack(
+                      item.trackTitle,
+                      item.trackSpotifyId,
+                      item.trackId,
+                    )
+                  }
+                >
+                  <Table.Td>
+                    <Group gap="sm" wrap="nowrap">
+                      {item.trackAlbumArt ? (
+                        <Avatar
+                          radius="sm"
+                          size="md"
+                          src={item.trackAlbumArt}
+                        />
+                      ) : (
+                        <Avatar color="blue" radius="sm" size="md">
+                          <Music size={20} />
+                        </Avatar>
+                      )}
+                      <Text className="font-medium" lineClamp={1} size="sm">
+                        {item.trackTitle}
+                      </Text>
+                    </Group>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text
+                      className="cursor-pointer hover:underline"
+                      lineClamp={1}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate({
+                          params: { artist: item.trackArtist },
+                          to: "/artists/$artist",
+                        });
+                      }}
+                      size="sm"
+                    >
+                      {item.trackArtist}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text
+                      className="cursor-pointer hover:underline"
+                      lineClamp={1}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (item.trackAlbum) {
+                          navigate({
+                            params: {
+                              album: item.trackAlbum,
+                              artist: item.trackArtist,
+                            },
+                            to: "/albums/$artist/$album",
+                          });
+                        }
+                      }}
+                      size="sm"
+                    >
+                      {item.trackAlbum || "-"}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge color="gray" size="sm" variant="light">
+                      {formatDate(item.playedAt)}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text className="text-gray-500" size="sm">
+                      {formatDuration(item.trackDuration)}
+                    </Text>
+                  </Table.Td>
+                </Table.Tr>
+              ))
+            )}
+          </Table.Tbody>
+        </Table>
+      </div>
+
+      {totalPages > 1 && (
+        <Center>
+          <Pagination
+            onChange={setPage}
+            total={totalPages}
+            value={page}
+            withEdges
+          />
+        </Center>
+      )}
+
+      <Text className="text-center text-gray-500" size="sm">
+        Showing {items.length} of {data?.total || 0} plays
+      </Text>
+    </Stack>
+  );
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -13,6 +13,7 @@
 import { Route as rootRoute } from "./routes/~__root";
 import { Route as TracksImport } from "./routes/~tracks";
 import { Route as PlaylistsImport } from "./routes/~playlists";
+import { Route as PlayHistoryImport } from "./routes/~play-history";
 import { Route as ArtistsImport } from "./routes/~artists";
 import { Route as AlbumsImport } from "./routes/~albums";
 import { Route as IndexImport } from "./routes/~index";
@@ -35,6 +36,12 @@ const TracksRoute = TracksImport.update({
 const PlaylistsRoute = PlaylistsImport.update({
   id: "/playlists",
   path: "/playlists",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const PlayHistoryRoute = PlayHistoryImport.update({
+  id: "/play-history",
+  path: "/play-history",
   getParentRoute: () => rootRoute,
 } as any);
 
@@ -121,6 +128,13 @@ declare module "@tanstack/react-router" {
       path: "/artists";
       fullPath: "/artists";
       preLoaderRoute: typeof ArtistsImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/play-history": {
+      id: "/play-history";
+      path: "/play-history";
+      fullPath: "/play-history";
+      preLoaderRoute: typeof PlayHistoryImport;
       parentRoute: typeof rootRoute;
     };
     "/playlists": {
@@ -235,6 +249,7 @@ export interface FileRoutesByFullPath {
   "/": typeof IndexRoute;
   "/albums": typeof AlbumsRouteWithChildren;
   "/artists": typeof ArtistsRouteWithChildren;
+  "/play-history": typeof PlayHistoryRoute;
   "/playlists": typeof PlaylistsRouteWithChildren;
   "/tracks": typeof TracksRoute;
   "/artists/$artist": typeof ArtistsArtistRoute;
@@ -248,6 +263,7 @@ export interface FileRoutesByFullPath {
 
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
+  "/play-history": typeof PlayHistoryRoute;
   "/tracks": typeof TracksRoute;
   "/artists/$artist": typeof ArtistsArtistRoute;
   "/auth/success": typeof AuthSuccessRoute;
@@ -263,6 +279,7 @@ export interface FileRoutesById {
   "/": typeof IndexRoute;
   "/albums": typeof AlbumsRouteWithChildren;
   "/artists": typeof ArtistsRouteWithChildren;
+  "/play-history": typeof PlayHistoryRoute;
   "/playlists": typeof PlaylistsRouteWithChildren;
   "/tracks": typeof TracksRoute;
   "/artists/$artist": typeof ArtistsArtistRoute;
@@ -280,6 +297,7 @@ export interface FileRouteTypes {
     | "/"
     | "/albums"
     | "/artists"
+    | "/play-history"
     | "/playlists"
     | "/tracks"
     | "/artists/$artist"
@@ -292,6 +310,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/"
+    | "/play-history"
     | "/tracks"
     | "/artists/$artist"
     | "/auth/success"
@@ -305,6 +324,7 @@ export interface FileRouteTypes {
     | "/"
     | "/albums"
     | "/artists"
+    | "/play-history"
     | "/playlists"
     | "/tracks"
     | "/artists/$artist"
@@ -321,6 +341,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
   AlbumsRoute: typeof AlbumsRouteWithChildren;
   ArtistsRoute: typeof ArtistsRouteWithChildren;
+  PlayHistoryRoute: typeof PlayHistoryRoute;
   PlaylistsRoute: typeof PlaylistsRouteWithChildren;
   TracksRoute: typeof TracksRoute;
   AuthSuccessRoute: typeof AuthSuccessRoute;
@@ -330,6 +351,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AlbumsRoute: AlbumsRouteWithChildren,
   ArtistsRoute: ArtistsRouteWithChildren,
+  PlayHistoryRoute: PlayHistoryRoute,
   PlaylistsRoute: PlaylistsRouteWithChildren,
   TracksRoute: TracksRoute,
   AuthSuccessRoute: AuthSuccessRoute,
@@ -348,6 +370,7 @@ export const routeTree = rootRoute
         "/",
         "/albums",
         "/artists",
+        "/play-history",
         "/playlists",
         "/tracks",
         "/auth/success"
@@ -369,6 +392,9 @@ export const routeTree = rootRoute
         "/artists/$artist",
         "/artists/"
       ]
+    },
+    "/play-history": {
+      "filePath": "~play-history.tsx"
     },
     "/playlists": {
       "filePath": "~playlists.tsx",

--- a/frontend/src/routes/~play-history.tsx
+++ b/frontend/src/routes/~play-history.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { PageTitle } from "../components/PageTitle";
+import { PlayHistoryTable } from "../components/PlayHistoryTable";
+
+const playHistorySearchSchema = z.object({
+  page: z.number().min(1).optional().catch(1),
+  pageSize: z.number().min(1).max(100).optional().catch(50),
+  search: z.string().optional(),
+  trackId: z.string().optional(),
+});
+
+export const Route = createFileRoute("/play-history")({
+  component: PlayHistoryPage,
+  validateSearch: (search) => playHistorySearchSchema.parse(search),
+});
+
+function PlayHistoryPage() {
+  return (
+    <div className="max-w-7xl mx-auto p-4">
+      <PageTitle title="Play History" />
+      <PlayHistoryTable />
+    </div>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Play History page featuring a searchable, paginated table of recently played tracks with artist, album, play date, and duration information.
  * Users can click tracks to play them directly, and click artists or albums to navigate to their respective pages.

* **Refactor**
  * Minor documentation and formatting adjustments to internal code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->